### PR TITLE
Bad debt handling/work submitter error checks

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -7,6 +7,7 @@ export enum EventType {
   LIQ_SCAN = 'liq_scan',
   POOL_EVENT = 'pool_event',
   USER_REFRESH = 'user_refresh',
+  CHECK_USER = 'check_user',
 }
 
 // ********* Shared **********
@@ -17,7 +18,8 @@ export type AppEvent =
   | OracleScanEvent
   | LiqScanEvent
   | PoolEventEvent
-  | UserRefreshEvent;
+  | UserRefreshEvent
+  | CheckUserEvent;
 
 /**
  * Base interface for all events.
@@ -75,4 +77,15 @@ export interface UserRefreshEvent extends BaseEvent {
    * The cutoff ledger such that any user data older than this will be refreshed.
    */
   cutoff: number;
+}
+
+/**
+ * Event to check a user for liquidations or bad debt.
+ */
+export interface CheckUserEvent extends BaseEvent {
+  type: EventType.CHECK_USER;
+  /**
+   * The user to check.
+   */
+  userId: string;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -97,7 +97,7 @@ async function main() {
   collectorInterval = setInterval(async () => {
     try {
       let sorobanHelper = new SorobanHelper();
-      let poolEventHandler = new PoolEventHandler(db, sorobanHelper);
+      let poolEventHandler = new PoolEventHandler(db, sorobanHelper, worker);
       await runCollector(worker, bidder, db, rpc, APP_CONFIG.poolAddress, poolEventHandler);
     } catch (e: any) {
       logger.error(`Error in collector`, e);

--- a/src/work_handler.ts
+++ b/src/work_handler.ts
@@ -121,6 +121,15 @@ export class WorkHandler {
             await this.sorobanHelper.loadUserPositionEstimate(user.user_id);
           updateUser(this.db, pool, poolUser, poolUserEstimate);
         }
+        break;
+      }
+      case EventType.CHECK_USER: {
+        const submissions = await checkUsersForLiquidationsAndBadDebt(this.db, this.sorobanHelper, [
+          appEvent.userId,
+        ]);
+        for (const submission of submissions) {
+          this.submissionQueue.addSubmission(submission, 2);
+        }
       }
       default:
         logger.error(`Unhandled event type: ${appEvent.type}`);

--- a/src/work_submitter.ts
+++ b/src/work_submitter.ts
@@ -71,6 +71,7 @@ export class WorkSubmitter extends SubmissionQueue<WorkSubmission> {
         (await sorobanHelper.loadAuction(userLiquidation.user, AuctionType.Liquidation)) !==
         undefined;
       if (auctionExists) {
+        logger.info(`User liquidation auction already exists for user: ${userLiquidation.user}`);
         return true;
       }
       await sorobanHelper.submitTransaction(op, APP_CONFIG.keypair);
@@ -118,6 +119,7 @@ export class WorkSubmitter extends SubmissionQueue<WorkSubmission> {
         (await sorobanHelper.loadAuction(APP_CONFIG.backstopAddress, AuctionType.BadDebt)) !==
         undefined;
       if (auctionExists) {
+        logger.info(`Bad debt auction already exists`);
         return true;
       }
       await sorobanHelper.submitTransaction(op, APP_CONFIG.keypair);

--- a/src/work_submitter.ts
+++ b/src/work_submitter.ts
@@ -67,8 +67,16 @@ export class WorkSubmitter extends SubmissionQueue<WorkSubmission> {
         user: userLiquidation.user,
         percent_liquidated: userLiquidation.liquidationPercent,
       });
+      const auctionExists =
+        (await sorobanHelper.loadAuction(userLiquidation.user, AuctionType.Liquidation)) !==
+        undefined;
+      if (auctionExists) {
+        return true;
+      }
       await sorobanHelper.submitTransaction(op, APP_CONFIG.keypair);
-      logger.info(`Submitted liquidation for user: ${userLiquidation.user}`);
+      const logMessage = `Successfully submitted liquidation for user: ${userLiquidation.user} Liquidation Percent: ${userLiquidation.liquidationPercent}`;
+      logger.info(logMessage);
+      await sendSlackNotification(logMessage);
       return true;
     } catch (e: any) {
       const logMessage =
@@ -106,6 +114,12 @@ export class WorkSubmitter extends SubmissionQueue<WorkSubmission> {
     try {
       const pool = new PoolContract(APP_CONFIG.poolAddress);
       let op = pool.newBadDebtAuction();
+      const auctionExists =
+        (await sorobanHelper.loadAuction(APP_CONFIG.backstopAddress, AuctionType.BadDebt)) !==
+        undefined;
+      if (auctionExists) {
+        return true;
+      }
       await sorobanHelper.submitTransaction(op, APP_CONFIG.keypair);
       const logMessage = `Successfully submitted bad debt auction`;
       logger.info(logMessage);
@@ -119,12 +133,21 @@ export class WorkSubmitter extends SubmissionQueue<WorkSubmission> {
     }
   }
 
-  onDrop(submission: WorkSubmission): void {
+  async onDrop(submission: WorkSubmission): Promise<void> {
     // TODO: Send slack alert for dropped submission
+    let logMessage: string;
     switch (submission.type) {
       case WorkSubmissionType.LiquidateUser:
-        logger.error(`Dropped liquidation for user: ${submission.user}`);
+        logMessage = `Dropped liquidation for user: ${submission.user}`;
+        break;
+      case WorkSubmissionType.BadDebtTransfer:
+        logMessage = `Dropped bad debt transfer for user: ${submission.user}`;
+        break;
+      case WorkSubmissionType.BadDebtAuction:
+        logMessage = `Dropped bad debt auction`;
         break;
     }
+    logger.error(logMessage);
+    await sendSlackNotification(logMessage);
   }
 }

--- a/test/bidder_submitter.test.ts
+++ b/test/bidder_submitter.test.ts
@@ -8,19 +8,23 @@ import { AuctioneerDatabase, AuctionEntry, AuctionType } from '../src/utils/db';
 import { SorobanHelper } from '../src/utils/soroban_helper';
 import { inMemoryAuctioneerDb } from './helpers/mocks';
 import { logger } from '../src/utils/logger';
-import * as auctionModule from '../src/auction';
-import { APP_CONFIG, Filler } from '../src/utils/config';
-import { Keypair, SorobanRpc } from '@stellar/stellar-sdk';
-import { PoolContract, RequestType } from '@blend-capital/blend-sdk';
+import {
+  buildFillRequests,
+  calculateAuctionValue,
+  calculateBlockFillAndPercent,
+  scaleAuction,
+} from '../src/auction';
+import { Keypair } from '@stellar/stellar-sdk';
+import { RequestType } from '@blend-capital/blend-sdk';
 import { sendSlackNotification } from '../src/utils/slack_notifier';
 
 // Mock dependencies
 jest.mock('../src/utils/db');
 jest.mock('../src/utils/soroban_helper');
 jest.mock('../src/auction');
-
-jest.mock('@blend-capital/blend-sdk');
 jest.mock('../src/utils/slack_notifier');
+jest.mock('@blend-capital/blend-sdk');
+jest.mock('../src/utils/soroban_helper');
 jest.mock('@stellar/stellar-sdk', () => {
   const actual = jest.requireActual('@stellar/stellar-sdk');
   return {
@@ -33,6 +37,7 @@ jest.mock('@stellar/stellar-sdk', () => {
     },
   };
 });
+
 jest.mock('../src/utils/config.js', () => {
   return {
     APP_CONFIG: {
@@ -48,229 +53,222 @@ jest.mock('../src/utils/config.js', () => {
     },
   };
 });
+
+jest.mock('../src/utils/logger.js', () => ({
+  logger: {
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
 describe('BidderSubmitter', () => {
   let bidderSubmitter: BidderSubmitter;
-  let mockDb: jest.Mocked<AuctioneerDatabase>;
+  let mockDb: AuctioneerDatabase;
+  let mockedSorobanHelper = new SorobanHelper() as jest.Mocked<SorobanHelper>;
+  let mockedSorobanHelperConstructor = SorobanHelper as jest.MockedClass<typeof SorobanHelper>;
+  mockedSorobanHelper.loadAuction.mockResolvedValue({
+    bid: new Map<string, bigint>([['USD', BigInt(123)]]),
+    lot: new Map<string, bigint>([['USD', BigInt(456)]]),
+    block: 500,
+  });
+  mockedSorobanHelper.submitTransaction.mockResolvedValue({
+    ledger: 1000,
+    txHash: 'mock-tx-hash',
+    latestLedgerCloseTime: 123,
+  } as any);
+  mockedSorobanHelper.network = {
+    rpc: 'test-rpc',
+    passphrase: 'test-pass',
+    opts: { allowHttp: true },
+  };
+  mockedSorobanHelperConstructor.mockReturnValue(mockedSorobanHelper);
 
+  const mockedSendSlackNotif = sendSlackNotification as jest.MockedFunction<
+    typeof sendSlackNotification
+  >;
+  let mockCalculateBlockFillAndPercent = calculateBlockFillAndPercent as jest.MockedFunction<
+    typeof calculateBlockFillAndPercent
+  >;
+  let mockScaleAuction = scaleAuction as jest.MockedFunction<typeof scaleAuction>;
+  let mockBuildFillRequests = buildFillRequests as jest.MockedFunction<typeof buildFillRequests>;
+  let mockCalculateAuctionValue = calculateAuctionValue as jest.MockedFunction<
+    typeof calculateAuctionValue
+  >;
   beforeEach(() => {
     jest.clearAllMocks();
-    mockDb = inMemoryAuctioneerDb() as jest.Mocked<AuctioneerDatabase>;
+    mockDb = inMemoryAuctioneerDb();
     bidderSubmitter = new BidderSubmitter(mockDb);
   });
 
-  describe('submit', () => {
-    it('should submit a bid successfully', async () => {
-      const mockLoadAuction = jest.fn().mockResolvedValue({
-        bid: new Map<string, bigint>([['USD', BigInt(123)]]),
-        lot: new Map<string, bigint>([['USD', BigInt(456)]]),
-        block: 500,
-      });
-      const mockSubmitTransaction = jest.fn().mockResolvedValue({
-        ledger: 1000,
-        txHash: 'mock-tx-hash',
-        latestLedgerCloseTime: '2023-01-01T00:00:00Z',
-      });
-
-      (SorobanHelper as jest.MockedClass<typeof SorobanHelper>).mockImplementation(
-        () =>
-          ({
-            loadAuction: mockLoadAuction,
-            submitTransaction: mockSubmitTransaction,
-            network: { rpc: 'mock-rpc', opts: {} },
-          }) as unknown as SorobanHelper
-      );
-
-      (PoolContract as jest.MockedClass<typeof PoolContract>).mockImplementation(
-        () =>
-          ({
-            submit: jest.fn().mockReturnValue('mock-operation'),
-          }) as unknown as PoolContract
-      );
-
-      jest
-        .spyOn(auctionModule, 'calculateBlockFillAndPercent')
-        .mockResolvedValue({ fillBlock: 1000, fillPercent: 0.5 });
-      jest.spyOn(auctionModule, 'scaleAuction').mockReturnValue({
-        bid: new Map<string, bigint>([['USD', BigInt(12)]]),
-        lot: new Map<string, bigint>([['USD', BigInt(34)]]),
-        block: 500,
-      });
-      jest.spyOn(auctionModule, 'buildFillRequests').mockResolvedValue([
-        {
-          request_type: RequestType.FillUserLiquidationAuction,
-          address: '',
-          amount: 0n,
-        },
-      ]);
-      jest.spyOn(auctionModule, 'calculateAuctionValue').mockResolvedValue({
-        bidValue: 123,
-        effectiveLiabilities: 456,
-        lotValue: 987,
-        effectiveCollateral: 654,
-      });
-
-      const submission: AuctionBid = {
-        type: BidderSubmissionType.BID,
-        filler: {
-          name: 'test-filler',
-          keypair: Keypair.random(),
-          minProfitPct: 0,
-          minHealthFactor: 0,
-          forceFill: false,
-          supportedBid: [],
-          supportedLot: [],
-        },
-        auctionEntry: {
-          user_id: 'test-user',
-          auction_type: AuctionType.Liquidation,
-          filler: 'test-filler',
-          start_block: 900,
-          fill_block: 1000,
-        } as AuctionEntry,
-      };
-
-      const result = await bidderSubmitter.submit(submission);
-
-      expect(result).toBe(true);
-      expect(mockLoadAuction).toHaveBeenCalledWith('test-user', AuctionType.Liquidation);
-      expect(mockSubmitTransaction).toHaveBeenCalled();
-      expect(mockDb.setFilledAuctionEntry).toHaveBeenCalled();
+  it('should submit a bid successfully', async () => {
+    mockCalculateBlockFillAndPercent.mockResolvedValue({ fillBlock: 1000, fillPercent: 50 });
+    mockScaleAuction.mockReturnValue({
+      bid: new Map<string, bigint>([['USD', BigInt(12)]]),
+      lot: new Map<string, bigint>([['USD', BigInt(34)]]),
+      block: 500,
+    });
+    mockBuildFillRequests.mockResolvedValue([
+      {
+        request_type: RequestType.FillUserLiquidationAuction,
+        address: '',
+        amount: 0n,
+      },
+    ]);
+    mockCalculateAuctionValue.mockResolvedValue({
+      bidValue: 123,
+      effectiveLiabilities: 456,
+      lotValue: 987,
+      effectiveCollateral: 654,
     });
 
-    it('should handle auction already filled', async () => {
-      const mockLoadAuction = jest.fn().mockResolvedValue(undefined);
-
-      (SorobanHelper as jest.MockedClass<typeof SorobanHelper>).mockImplementation(
-        () =>
-          ({
-            loadAuction: mockLoadAuction,
-            network: { rpc: 'mock-rpc', opts: {} },
-          }) as unknown as SorobanHelper
-      );
-
-      const submission: AuctionBid = {
-        type: BidderSubmissionType.BID,
-        filler: {
-          name: 'test-filler',
-          keypair: Keypair.random(),
-          minProfitPct: 0,
-          minHealthFactor: 0,
-          forceFill: false,
-          supportedBid: [],
-          supportedLot: [],
-        },
-        auctionEntry: {
-          user_id: 'test-user',
-          auction_type: AuctionType.Liquidation,
-        } as AuctionEntry,
-      };
-
-      const result = await bidderSubmitter.submit(submission);
-
-      expect(result).toBe(true);
-      expect(mockDb.deleteAuctionEntry).toHaveBeenCalledWith('test-user', AuctionType.Liquidation);
-    });
-  });
-
-  describe('containsAuction', () => {
-    it('should return true if auction is in the queue', () => {
-      const auctionEntry: AuctionEntry = {
+    const submission: AuctionBid = {
+      type: BidderSubmissionType.BID,
+      filler: {
+        name: 'test-filler',
+        keypair: Keypair.random(),
+        minProfitPct: 0,
+        minHealthFactor: 0,
+        forceFill: false,
+        supportedBid: [],
+        supportedLot: [],
+      },
+      auctionEntry: {
         user_id: 'test-user',
         auction_type: AuctionType.Liquidation,
-      } as AuctionEntry;
+        filler: 'test-filler',
+        start_block: 900,
+        fill_block: 1000,
+      } as AuctionEntry,
+    };
 
-      bidderSubmitter.addSubmission(
-        {
-          type: BidderSubmissionType.BID,
-          auctionEntry: auctionEntry,
-        } as AuctionBid,
-        1
-      );
+    const result = await bidderSubmitter.submit(submission);
 
-      expect(bidderSubmitter.containsAuction(auctionEntry)).toBe(true);
-    });
-
-    it('should return false if auction is not in the queue', () => {
-      const auctionEntry: AuctionEntry = {
-        user_id: 'test-user',
-        auction_type: AuctionType.Liquidation,
-      } as AuctionEntry;
-
-      bidderSubmitter['submissions'] = [];
-
-      expect(bidderSubmitter.containsAuction(auctionEntry)).toBe(false);
-    });
+    expect(result).toBe(true);
+    expect(mockedSorobanHelper.loadAuction).toHaveBeenCalledWith(
+      'test-user',
+      AuctionType.Liquidation
+    );
+    expect(mockedSorobanHelper.submitTransaction).toHaveBeenCalled();
+    expect(mockDb.setFilledAuctionEntry).toHaveBeenCalled();
   });
 
-  describe('onDrop', () => {
-    let mockedSendSlackNotif = sendSlackNotification as jest.MockedFunction<
-      typeof sendSlackNotification
-    >;
-    const loggerSpy = jest.spyOn(logger, 'error').mockImplementation();
+  it('should handle auction already filled', async () => {
+    mockedSorobanHelper.loadAuction.mockResolvedValue(undefined);
+    mockedSorobanHelperConstructor.mockReturnValue(mockedSorobanHelper);
+    const submission: AuctionBid = {
+      type: BidderSubmissionType.BID,
+      filler: {
+        name: 'test-filler',
+        keypair: Keypair.random(),
+        minProfitPct: 0,
+        minHealthFactor: 0,
+        forceFill: false,
+        supportedBid: [],
+        supportedLot: [],
+      },
+      auctionEntry: {
+        user_id: 'test-user',
+        auction_type: AuctionType.Liquidation,
+      } as AuctionEntry,
+    };
 
-    it('should handle dropped bid', async () => {
-      const submission: AuctionBid = {
+    const result = await bidderSubmitter.submit(submission);
+
+    expect(result).toBe(true);
+    expect(mockDb.deleteAuctionEntry).toHaveBeenCalledWith('test-user', AuctionType.Liquidation);
+  });
+
+  it('should return true if auction is in the queue', () => {
+    const auctionEntry: AuctionEntry = {
+      user_id: 'test-user',
+      auction_type: AuctionType.Liquidation,
+    } as AuctionEntry;
+
+    bidderSubmitter.addSubmission(
+      {
         type: BidderSubmissionType.BID,
-        filler: {
-          name: 'test-filler',
-          keypair: Keypair.random(),
-          minProfitPct: 0,
-          minHealthFactor: 0,
-          forceFill: false,
-          supportedBid: [],
-          supportedLot: [],
-        },
-        auctionEntry: {
-          user_id: 'test-user',
-          auction_type: AuctionType.Liquidation,
-          start_block: 900,
-          fill_block: 1000,
-        } as AuctionEntry,
-      };
+        auctionEntry: auctionEntry,
+      } as AuctionBid,
+      1
+    );
 
-      await bidderSubmitter.onDrop(submission);
+    expect(bidderSubmitter.containsAuction(auctionEntry)).toBe(true);
+  });
 
-      expect(mockDb.deleteAuctionEntry).toHaveBeenCalledWith('test-user', AuctionType.Liquidation);
-      expect(loggerSpy).toHaveBeenCalledWith(
-        `Dropped auction bid\n` +
-          `Type: ${AuctionType[submission.auctionEntry.auction_type]}\n` +
-          `User: ${submission.auctionEntry.user_id}\n` +
-          `Start Block: ${submission.auctionEntry.start_block}\n` +
-          `Fill Block: ${submission.auctionEntry.fill_block}\n` +
-          `Filler: ${submission.filler.name}\n`
-      );
-      expect(mockedSendSlackNotif).toHaveBeenCalledWith(
-        `Dropped auction bid\n` +
-          `Type: ${AuctionType[submission.auctionEntry.auction_type]}\n` +
-          `User: ${submission.auctionEntry.user_id}\n` +
-          `Start Block: ${submission.auctionEntry.start_block}\n` +
-          `Fill Block: ${submission.auctionEntry.fill_block}\n` +
-          `Filler: ${submission.filler.name}\n`
-      );
-    });
+  it('should return false if auction is not in the queue', () => {
+    const auctionEntry: AuctionEntry = {
+      user_id: 'test-user',
+      auction_type: AuctionType.Liquidation,
+    } as AuctionEntry;
 
-    it('should handle dropped unwind', async () => {
-      const submission: FillerUnwind = {
-        type: BidderSubmissionType.UNWIND,
-        filler: {
-          name: 'test-filler',
-          keypair: Keypair.random(),
-          minProfitPct: 0,
-          minHealthFactor: 0,
-          forceFill: false,
-          supportedBid: [],
-          supportedLot: [],
-        },
-      };
+    bidderSubmitter['submissions'] = [];
 
-      await bidderSubmitter.onDrop(submission);
+    expect(bidderSubmitter.containsAuction(auctionEntry)).toBe(false);
+  });
 
-      expect(loggerSpy).toHaveBeenCalledWith(
-        `Dropped filler unwind\n` + `Filler: ${submission.filler.name}\n`
-      );
-      expect(mockedSendSlackNotif).toHaveBeenCalledWith(
-        `Dropped filler unwind\n` + `Filler: ${submission.filler.name}\n`
-      );
-    });
+  it('should handle dropped bid', async () => {
+    const submission: AuctionBid = {
+      type: BidderSubmissionType.BID,
+      filler: {
+        name: 'test-filler',
+        keypair: Keypair.random(),
+        minProfitPct: 0,
+        minHealthFactor: 0,
+        forceFill: false,
+        supportedBid: [],
+        supportedLot: [],
+      },
+      auctionEntry: {
+        user_id: 'test-user',
+        auction_type: AuctionType.Liquidation,
+        start_block: 900,
+        fill_block: 1000,
+      } as AuctionEntry,
+    };
+
+    await bidderSubmitter.onDrop(submission);
+
+    expect(mockDb.deleteAuctionEntry).toHaveBeenCalledWith('test-user', AuctionType.Liquidation);
+    expect(logger.error).toHaveBeenCalledWith(
+      `Dropped auction bid\n` +
+        `Type: ${AuctionType[submission.auctionEntry.auction_type]}\n` +
+        `User: ${submission.auctionEntry.user_id}\n` +
+        `Start Block: ${submission.auctionEntry.start_block}\n` +
+        `Fill Block: ${submission.auctionEntry.fill_block}\n` +
+        `Filler: ${submission.filler.name}\n`
+    );
+    expect(mockedSendSlackNotif).toHaveBeenCalledWith(
+      `Dropped auction bid\n` +
+        `Type: ${AuctionType[submission.auctionEntry.auction_type]}\n` +
+        `User: ${submission.auctionEntry.user_id}\n` +
+        `Start Block: ${submission.auctionEntry.start_block}\n` +
+        `Fill Block: ${submission.auctionEntry.fill_block}\n` +
+        `Filler: ${submission.filler.name}\n`
+    );
+  });
+
+  it('should handle dropped unwind', async () => {
+    const submission: FillerUnwind = {
+      type: BidderSubmissionType.UNWIND,
+      filler: {
+        name: 'test-filler',
+        keypair: Keypair.random(),
+        minProfitPct: 0,
+        minHealthFactor: 0,
+        forceFill: false,
+        supportedBid: [],
+        supportedLot: [],
+      },
+    };
+
+    await bidderSubmitter.onDrop(submission);
+
+    expect(logger.error).toHaveBeenCalledWith(
+      `Dropped filler unwind\n` + `Filler: ${submission.filler.name}\n`
+    );
+    expect(mockedSendSlackNotif).toHaveBeenCalledWith(
+      `Dropped filler unwind\n` + `Filler: ${submission.filler.name}\n`
+    );
   });
 });

--- a/test/bidder_submitter.test.ts
+++ b/test/bidder_submitter.test.ts
@@ -1,0 +1,276 @@
+import {
+  BidderSubmitter,
+  BidderSubmissionType,
+  AuctionBid,
+  FillerUnwind,
+} from '../src/bidder_submitter';
+import { AuctioneerDatabase, AuctionEntry, AuctionType } from '../src/utils/db';
+import { SorobanHelper } from '../src/utils/soroban_helper';
+import { inMemoryAuctioneerDb } from './helpers/mocks';
+import { logger } from '../src/utils/logger';
+import * as auctionModule from '../src/auction';
+import { APP_CONFIG, Filler } from '../src/utils/config';
+import { Keypair, SorobanRpc } from '@stellar/stellar-sdk';
+import { PoolContract, RequestType } from '@blend-capital/blend-sdk';
+import { sendSlackNotification } from '../src/utils/slack_notifier';
+
+// Mock dependencies
+jest.mock('../src/utils/db');
+jest.mock('../src/utils/soroban_helper');
+jest.mock('../src/auction');
+
+jest.mock('@blend-capital/blend-sdk');
+jest.mock('../src/utils/slack_notifier');
+jest.mock('@stellar/stellar-sdk', () => {
+  const actual = jest.requireActual('@stellar/stellar-sdk');
+  return {
+    ...actual,
+    SorobanRpc: {
+      ...actual.SorobanRpc,
+      Server: jest.fn().mockImplementation(() => ({
+        getLatestLedger: jest.fn().mockResolvedValue({ sequence: 999 }),
+      })),
+    },
+  };
+});
+jest.mock('../src/utils/config.js', () => {
+  return {
+    APP_CONFIG: {
+      rpcURL: 'http://localhost:8000/rpc',
+      networkPassphrase: 'Public Global Stellar Network ; September 2015',
+      poolAddress: 'CBP7NO6F7FRDHSOFQBT2L2UWYIZ2PU76JKVRYAQTG3KZSQLYAOKIF2WB',
+      backstopAddress: 'CAO3AGAMZVRMHITL36EJ2VZQWKYRPWMQAPDQD5YEOF3GIF7T44U4JAL3',
+      backstopTokenAddress: 'CAS3FL6TLZKDGGSISDBWGGPXT3NRR4DYTZD7YOD3HMYO6LTJUVGRVEAM',
+      usdcAddress: 'CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75',
+      blndAddress: 'CD25MNVTZDL4Y3XBCPCJXGXATV5WUHHOWMYFF4YBEGU5FCPGMYTVG5JY',
+      keypair: '',
+      fillers: [],
+    },
+  };
+});
+describe('BidderSubmitter', () => {
+  let bidderSubmitter: BidderSubmitter;
+  let mockDb: jest.Mocked<AuctioneerDatabase>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDb = inMemoryAuctioneerDb() as jest.Mocked<AuctioneerDatabase>;
+    bidderSubmitter = new BidderSubmitter(mockDb);
+  });
+
+  describe('submit', () => {
+    it('should submit a bid successfully', async () => {
+      const mockLoadAuction = jest.fn().mockResolvedValue({
+        bid: new Map<string, bigint>([['USD', BigInt(123)]]),
+        lot: new Map<string, bigint>([['USD', BigInt(456)]]),
+        block: 500,
+      });
+      const mockSubmitTransaction = jest.fn().mockResolvedValue({
+        ledger: 1000,
+        txHash: 'mock-tx-hash',
+        latestLedgerCloseTime: '2023-01-01T00:00:00Z',
+      });
+
+      (SorobanHelper as jest.MockedClass<typeof SorobanHelper>).mockImplementation(
+        () =>
+          ({
+            loadAuction: mockLoadAuction,
+            submitTransaction: mockSubmitTransaction,
+            network: { rpc: 'mock-rpc', opts: {} },
+          }) as unknown as SorobanHelper
+      );
+
+      (PoolContract as jest.MockedClass<typeof PoolContract>).mockImplementation(
+        () =>
+          ({
+            submit: jest.fn().mockReturnValue('mock-operation'),
+          }) as unknown as PoolContract
+      );
+
+      jest
+        .spyOn(auctionModule, 'calculateBlockFillAndPercent')
+        .mockResolvedValue({ fillBlock: 1000, fillPercent: 0.5 });
+      jest.spyOn(auctionModule, 'scaleAuction').mockReturnValue({
+        bid: new Map<string, bigint>([['USD', BigInt(12)]]),
+        lot: new Map<string, bigint>([['USD', BigInt(34)]]),
+        block: 500,
+      });
+      jest.spyOn(auctionModule, 'buildFillRequests').mockResolvedValue([
+        {
+          request_type: RequestType.FillUserLiquidationAuction,
+          address: '',
+          amount: 0n,
+        },
+      ]);
+      jest.spyOn(auctionModule, 'calculateAuctionValue').mockResolvedValue({
+        bidValue: 123,
+        effectiveLiabilities: 456,
+        lotValue: 987,
+        effectiveCollateral: 654,
+      });
+
+      const submission: AuctionBid = {
+        type: BidderSubmissionType.BID,
+        filler: {
+          name: 'test-filler',
+          keypair: Keypair.random(),
+          minProfitPct: 0,
+          minHealthFactor: 0,
+          forceFill: false,
+          supportedBid: [],
+          supportedLot: [],
+        },
+        auctionEntry: {
+          user_id: 'test-user',
+          auction_type: AuctionType.Liquidation,
+          filler: 'test-filler',
+          start_block: 900,
+          fill_block: 1000,
+        } as AuctionEntry,
+      };
+
+      const result = await bidderSubmitter.submit(submission);
+
+      expect(result).toBe(true);
+      expect(mockLoadAuction).toHaveBeenCalledWith('test-user', AuctionType.Liquidation);
+      expect(mockSubmitTransaction).toHaveBeenCalled();
+      expect(mockDb.setFilledAuctionEntry).toHaveBeenCalled();
+    });
+
+    it('should handle auction already filled', async () => {
+      const mockLoadAuction = jest.fn().mockResolvedValue(undefined);
+
+      (SorobanHelper as jest.MockedClass<typeof SorobanHelper>).mockImplementation(
+        () =>
+          ({
+            loadAuction: mockLoadAuction,
+            network: { rpc: 'mock-rpc', opts: {} },
+          }) as unknown as SorobanHelper
+      );
+
+      const submission: AuctionBid = {
+        type: BidderSubmissionType.BID,
+        filler: {
+          name: 'test-filler',
+          keypair: Keypair.random(),
+          minProfitPct: 0,
+          minHealthFactor: 0,
+          forceFill: false,
+          supportedBid: [],
+          supportedLot: [],
+        },
+        auctionEntry: {
+          user_id: 'test-user',
+          auction_type: AuctionType.Liquidation,
+        } as AuctionEntry,
+      };
+
+      const result = await bidderSubmitter.submit(submission);
+
+      expect(result).toBe(true);
+      expect(mockDb.deleteAuctionEntry).toHaveBeenCalledWith('test-user', AuctionType.Liquidation);
+    });
+  });
+
+  describe('containsAuction', () => {
+    it('should return true if auction is in the queue', () => {
+      const auctionEntry: AuctionEntry = {
+        user_id: 'test-user',
+        auction_type: AuctionType.Liquidation,
+      } as AuctionEntry;
+
+      bidderSubmitter.addSubmission(
+        {
+          type: BidderSubmissionType.BID,
+          auctionEntry: auctionEntry,
+        } as AuctionBid,
+        1
+      );
+
+      expect(bidderSubmitter.containsAuction(auctionEntry)).toBe(true);
+    });
+
+    it('should return false if auction is not in the queue', () => {
+      const auctionEntry: AuctionEntry = {
+        user_id: 'test-user',
+        auction_type: AuctionType.Liquidation,
+      } as AuctionEntry;
+
+      bidderSubmitter['submissions'] = [];
+
+      expect(bidderSubmitter.containsAuction(auctionEntry)).toBe(false);
+    });
+  });
+
+  describe('onDrop', () => {
+    let mockedSendSlackNotif = sendSlackNotification as jest.MockedFunction<
+      typeof sendSlackNotification
+    >;
+    const loggerSpy = jest.spyOn(logger, 'error').mockImplementation();
+
+    it('should handle dropped bid', async () => {
+      const submission: AuctionBid = {
+        type: BidderSubmissionType.BID,
+        filler: {
+          name: 'test-filler',
+          keypair: Keypair.random(),
+          minProfitPct: 0,
+          minHealthFactor: 0,
+          forceFill: false,
+          supportedBid: [],
+          supportedLot: [],
+        },
+        auctionEntry: {
+          user_id: 'test-user',
+          auction_type: AuctionType.Liquidation,
+          start_block: 900,
+          fill_block: 1000,
+        } as AuctionEntry,
+      };
+
+      await bidderSubmitter.onDrop(submission);
+
+      expect(mockDb.deleteAuctionEntry).toHaveBeenCalledWith('test-user', AuctionType.Liquidation);
+      expect(loggerSpy).toHaveBeenCalledWith(
+        `Dropped auction bid\n` +
+          `Type: ${AuctionType[submission.auctionEntry.auction_type]}\n` +
+          `User: ${submission.auctionEntry.user_id}\n` +
+          `Start Block: ${submission.auctionEntry.start_block}\n` +
+          `Fill Block: ${submission.auctionEntry.fill_block}\n` +
+          `Filler: ${submission.filler.name}\n`
+      );
+      expect(mockedSendSlackNotif).toHaveBeenCalledWith(
+        `Dropped auction bid\n` +
+          `Type: ${AuctionType[submission.auctionEntry.auction_type]}\n` +
+          `User: ${submission.auctionEntry.user_id}\n` +
+          `Start Block: ${submission.auctionEntry.start_block}\n` +
+          `Fill Block: ${submission.auctionEntry.fill_block}\n` +
+          `Filler: ${submission.filler.name}\n`
+      );
+    });
+
+    it('should handle dropped unwind', async () => {
+      const submission: FillerUnwind = {
+        type: BidderSubmissionType.UNWIND,
+        filler: {
+          name: 'test-filler',
+          keypair: Keypair.random(),
+          minProfitPct: 0,
+          minHealthFactor: 0,
+          forceFill: false,
+          supportedBid: [],
+          supportedLot: [],
+        },
+      };
+
+      await bidderSubmitter.onDrop(submission);
+
+      expect(loggerSpy).toHaveBeenCalledWith(
+        `Dropped filler unwind\n` + `Filler: ${submission.filler.name}\n`
+      );
+      expect(mockedSendSlackNotif).toHaveBeenCalledWith(
+        `Dropped filler unwind\n` + `Filler: ${submission.filler.name}\n`
+      );
+    });
+  });
+});

--- a/test/work_handler.test.ts
+++ b/test/work_handler.test.ts
@@ -24,15 +24,7 @@ jest.mock('../src/liquidations');
 jest.mock('../src/user');
 jest.mock('../src/utils/messages');
 jest.mock('../src/utils/logger');
-jest.mock('../src/utils/soroban_helper', () => {
-  return {
-    SorobanHelper: jest.fn().mockImplementation(() => ({
-      loadPoolOracle: jest.fn(),
-      loadPool: jest.fn(),
-      loadUserPositionEstimate: jest.fn(),
-    })),
-  };
-});
+jest.mock('../src/utils/soroban_helper');
 describe('WorkHandler', () => {
   let db: jest.Mocked<AuctioneerDatabase>;
   let submissionQueue: jest.Mocked<WorkSubmitter>;
@@ -41,6 +33,7 @@ describe('WorkHandler', () => {
   let workHandler: WorkHandler;
 
   beforeEach(() => {
+    jest.clearAllMocks();
     db = {
       getUserEntriesWithLiability: jest.fn(),
       getUserEntriesWithCollateral: jest.fn(),
@@ -61,10 +54,6 @@ describe('WorkHandler', () => {
       loadUserPositionEstimate: jest.fn(),
     } as unknown as jest.Mocked<SorobanHelper>;
     workHandler = new WorkHandler(db, submissionQueue, oracleHistory, sorobanHelper);
-  });
-
-  afterEach(() => {
-    jest.clearAllMocks();
   });
 
   it('should handle ORACLE_SCAN event', async () => {

--- a/test/work_submitter.test.ts
+++ b/test/work_submitter.test.ts
@@ -1,0 +1,200 @@
+import { WorkSubmitter, WorkSubmissionType, WorkSubmission } from '../src/work_submitter';
+import { AuctioneerDatabase, AuctionType } from '../src/utils/db';
+import { SorobanHelper } from '../src/utils/soroban_helper';
+import { inMemoryAuctioneerDb } from './helpers/mocks';
+import { logger } from '../src/utils/logger';
+import { sendSlackNotification } from '../src/utils/slack_notifier';
+
+// Mock dependencies
+jest.mock('../src/utils/db');
+jest.mock('../src/utils/soroban_helper');
+jest.mock('@blend-capital/blend-sdk');
+jest.mock('../src/utils/slack_notifier');
+jest.mock('../src/utils/logger');
+
+describe('WorkSubmitter', () => {
+  let workSubmitter: WorkSubmitter;
+  let mockDb: jest.Mocked<AuctioneerDatabase>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDb = inMemoryAuctioneerDb() as jest.Mocked<AuctioneerDatabase>;
+    workSubmitter = new WorkSubmitter(mockDb);
+  });
+
+  describe('submitUserLiquidation', () => {
+    const mockedSendSlackNotif = sendSlackNotification as jest.MockedFunction<
+      typeof sendSlackNotification
+    >;
+    const loggerInfoSpy = jest.spyOn(logger, 'info').mockImplementation();
+    it('should submit a user liquidation successfully', async () => {
+      const mockLoadAuction = jest.fn().mockResolvedValue(undefined);
+      const mockSubmitTransaction = jest.fn().mockResolvedValue(undefined);
+
+      (SorobanHelper as jest.MockedClass<typeof SorobanHelper>).mockImplementation(
+        () =>
+          ({
+            loadAuction: mockLoadAuction,
+            submitTransaction: mockSubmitTransaction,
+          }) as unknown as SorobanHelper
+      );
+      const submission = {
+        type: WorkSubmissionType.LiquidateUser,
+        user: 'testUser',
+        liquidationPercent: BigInt(50),
+      };
+
+      const result = await workSubmitter.submit(submission);
+      const expectedLogMessage = `Successfully submitted liquidation for user: ${submission.user} Liquidation Percent: ${submission.liquidationPercent}`;
+      expect(result).toBe(true);
+      expect(mockLoadAuction).toHaveBeenCalledWith('testUser', AuctionType.Liquidation);
+      expect(mockSubmitTransaction).toHaveBeenCalled();
+      expect(loggerInfoSpy).toHaveBeenCalledWith(expectedLogMessage);
+      expect(mockedSendSlackNotif).toHaveBeenCalledWith(expectedLogMessage);
+    });
+
+    it('should not submit if auction already exists', async () => {
+      const mockLoadAuction = jest.fn().mockResolvedValue({
+        bid: new Map<string, bigint>([['USD', BigInt(123)]]),
+        lot: new Map<string, bigint>([['USD', BigInt(456)]]),
+        block: 500,
+      });
+      const mockSubmitTransaction = jest.fn().mockResolvedValue(undefined);
+
+      (SorobanHelper as jest.MockedClass<typeof SorobanHelper>).mockImplementation(
+        () =>
+          ({
+            loadAuction: mockLoadAuction,
+            submitTransaction: mockSubmitTransaction,
+          }) as unknown as SorobanHelper
+      );
+      const submission = {
+        type: WorkSubmissionType.LiquidateUser,
+        user: 'testUser',
+        liquidationPercent: BigInt(50),
+      };
+
+      const result = await workSubmitter.submit(submission);
+
+      expect(result).toBe(true);
+      expect(mockSubmitTransaction).not.toHaveBeenCalled();
+      expect(loggerInfoSpy).not.toHaveBeenCalled();
+      expect(mockedSendSlackNotif).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('submitBadDebtTransfer', () => {
+    it('should submit a bad debt transfer successfully', async () => {
+      const mockLoadAuction = jest.fn().mockResolvedValue(undefined);
+      const mockSubmitTransaction = jest.fn().mockResolvedValue(undefined);
+
+      (SorobanHelper as jest.MockedClass<typeof SorobanHelper>).mockImplementation(
+        () =>
+          ({
+            loadAuction: mockLoadAuction,
+            submitTransaction: mockSubmitTransaction,
+          }) as unknown as SorobanHelper
+      );
+      const submission: WorkSubmission = {
+        type: WorkSubmissionType.BadDebtTransfer,
+        user: 'testUser',
+      };
+
+      const result = await workSubmitter.submit(submission);
+      const expectedLogMessage = `Successfully submitted bad debt transfer for user: ${submission.user}`;
+      expect(result).toBe(true);
+      expect(mockSubmitTransaction).toHaveBeenCalled();
+      expect(logger.info).toHaveBeenCalledWith(expectedLogMessage);
+      expect(sendSlackNotification).toHaveBeenCalledWith(expectedLogMessage);
+    });
+  });
+
+  describe('submitBadDebtAuction', () => {
+    it('should submit a bad debt auction successfully', async () => {
+      const mockLoadAuction = jest.fn().mockResolvedValue(undefined);
+      const mockSubmitTransaction = jest.fn().mockResolvedValue(undefined);
+
+      (SorobanHelper as jest.MockedClass<typeof SorobanHelper>).mockImplementation(
+        () =>
+          ({
+            loadAuction: mockLoadAuction,
+            submitTransaction: mockSubmitTransaction,
+          }) as unknown as SorobanHelper
+      );
+      const submission: WorkSubmission = {
+        type: WorkSubmissionType.BadDebtAuction,
+      };
+
+      const result = await workSubmitter.submit(submission);
+      const expectedLogMessage = `Successfully submitted bad debt auction`;
+      expect(result).toBe(true);
+      expect(mockSubmitTransaction).toHaveBeenCalled();
+      expect(logger.info).toHaveBeenCalledWith(expectedLogMessage);
+      expect(sendSlackNotification).toHaveBeenCalledWith(expectedLogMessage);
+    });
+
+    it('should not submit if auction already exists', async () => {
+      const mockLoadAuction = jest.fn().mockResolvedValue({});
+      const mockSubmitTransaction = jest.fn().mockResolvedValue(undefined);
+
+      (SorobanHelper as jest.MockedClass<typeof SorobanHelper>).mockImplementation(
+        () =>
+          ({
+            loadAuction: mockLoadAuction,
+            submitTransaction: mockSubmitTransaction,
+          }) as unknown as SorobanHelper
+      );
+      const submission: WorkSubmission = {
+        type: WorkSubmissionType.BadDebtAuction,
+      };
+
+      const result = await workSubmitter.submit(submission);
+
+      expect(result).toBe(true);
+      expect(mockSubmitTransaction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onDrop', () => {
+    it('should log an error when a liquidation is dropped', () => {
+      const loggerSpy = jest.spyOn(logger, 'error').mockImplementation();
+
+      const submission = {
+        type: WorkSubmissionType.LiquidateUser,
+        user: 'testUser',
+        liquidationPercent: BigInt(50),
+      };
+
+      workSubmitter.onDrop(submission);
+
+      expect(loggerSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Dropped liquidation for user: testUser')
+      );
+    });
+    it('should log an error when a bad debt transfer is dropped', () => {
+      const loggerSpy = jest.spyOn(logger, 'error').mockImplementation();
+
+      const submission: WorkSubmission = {
+        type: WorkSubmissionType.BadDebtTransfer,
+        user: 'testUser',
+      };
+
+      workSubmitter.onDrop(submission);
+
+      expect(loggerSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Dropped bad debt transfer for user: testUser')
+      );
+    });
+    it('should log an error when a bad debt auction is dropped', () => {
+      const loggerSpy = jest.spyOn(logger, 'error').mockImplementation();
+
+      const submission: WorkSubmission = {
+        type: WorkSubmissionType.BadDebtAuction,
+      };
+
+      workSubmitter.onDrop(submission);
+
+      expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('Dropped bad debt auction'));
+    });
+  });
+});


### PR DESCRIPTION
- Check backstop on BadDebt transfers and BadDebt auctions
- Check if auction exists before submitting the transaction to create them. This prevents error logs from being unnecessarily logged.
- Add handling of dropped BadDebtTransfer and BadDebtAuction submissions
- Add logging to dropped submissions on the bidder_submitter
- Add unit tests for work_submitter and bidder_submitter